### PR TITLE
Expose vote widget interaction event

### DIFF
--- a/game_rule_device.verse
+++ b/game_rule_device.verse
@@ -16,7 +16,9 @@ game_rule_device := class(creative_device):
     @editable
     TeamScoreDisplay : team_score_display_device = team_score_display_device{}
     @editable
-    InfectionDisplay : infection_mode_display_device = infection_mode_display_device{} 
+    InfectionDisplay : infection_mode_display_device = infection_mode_display_device{}
+    @editable
+    VoteSelectionDisplay : vote_selection_widget_device = vote_selection_widget_device{}
 
     #// SHIP
     @editable
@@ -62,6 +64,8 @@ game_rule_device := class(creative_device):
     # Infectionモード有効フラグ
     var IsInfectionMode : logic = false
     var PlayerAddedSubscribed : logic = false
+
+    var VoteTeleportTriggered : logic = false
     
     # チーム変更エフェクト用（オプション）
     @editable
@@ -116,9 +120,27 @@ game_rule_device := class(creative_device):
         vote_optionB.WinVoteEvent.Subscribe(OnVoteBSuccess)
         #vote_optionC.WinVoteEvent.Subscribe(OnVoteCSuccess)
         #vote_optionD.WinVoteEvent.Subscribe(OnVoteDSuccess)
-    
-        vote_group.EndVoteEvent.Subscribe(player_teleport)
+
+        VoteSelectionDisplay.OnVoteButtonClickedEvent().Subscribe(HandleVoteWidgetInteraction)
+        vote_group.StartVoteEvent.Subscribe(OnVoteStarted)
+        vote_group.EndVoteEvent.Subscribe(OnVoteEnded)
         vote_group.VoteTiedEvent.Subscribe(randam_vote_select)
+
+    OnVoteStarted(_: ?agent) : void =
+        Print("Vote started - showing selection UI")
+        set VoteTeleportTriggered = false
+        VoteSelectionDisplay.ShowVoteSelectionUI()
+
+    OnVoteEnded(_: ?agent) : void =
+        Print("Vote ended - hiding selection UI")
+        VoteSelectionDisplay.HideVoteSelectionUI()
+        if(VoteTeleportTriggered = false):
+            set VoteTeleportTriggered = true
+            player_teleport()
+
+    HandleVoteWidgetInteraction(InteractingPlayer:player):void=
+        Print("Vote widget button pressed by {InteractingPlayer}")
+        # ここに任意の処理を追加。例: HUDメッセージ表示やメニューオープンなど
 
     # 投票終了後に全プレイヤーをチーム別にテレポート
     player_teleport() : void =
@@ -163,8 +185,12 @@ game_rule_device := class(creative_device):
             Print("Random selection: Infection Mode")
             OnVoteBSuccess(false)
 
-        # 全プレイヤーをテレポート
-        player_teleport()
+        VoteSelectionDisplay.HideVoteSelectionUI()
+
+        if(VoteTeleportTriggered = false):
+            set VoteTeleportTriggered = true
+            # 全プレイヤーをテレポート
+            player_teleport()
 
     # プレイヤーをランダムなテレポーターデバイスにテレポート
     TeleportPlayerToRandomDevice(Player : agent, Teleporters : []teleporter_device, TeamName : string) : void =

--- a/vote_selection_widget.verse
+++ b/vote_selection_widget.verse
@@ -1,0 +1,125 @@
+using { /Fortnite.com/Devices }
+using { /Fortnite.com/UI }
+using { /Fortnite.com/Game }
+using { /Fortnite.com/Characters }
+using { /UnrealEngine.com/Temporary/UI }
+using { /UnrealEngine.com/Temporary/Diagnostics }
+using { /Verse.org/Colors }
+
+vote_selection_widget := class():
+    Device : vote_selection_widget_device
+    OurPlayerUI : player_ui
+    AssociatedPlayer : player
+    var Canvas : ?canvas
+
+    ButtonLabel<localizes>(value:string) : message = "{value}"
+    BodyText<localizes>(value:string) : message = "{value}"
+
+    VoteTitle:text_block = text_block {
+        DefaultTextColor := NamedColors.White,
+        DefaultText := BodyText("SELECT GAME MODE")
+    }
+
+    VoteDescription:text_block = text_block {
+        DefaultTextColor := NamedColors.LightGray,
+        DefaultText := BodyText("Cast your vote before the battle starts!")
+    }
+
+    VoteButton:button_loud = button_loud {
+        DefaultText := ButtonLabel("OPEN VOTE")
+    }
+
+    InitWidget():void=
+        VoteButton.OnClickEvent().Subscribe(OnVoteButtonClicked)
+        NewCanvas := CreateVoteSelectionUI()
+        OurPlayerUI.AddWidget(NewCanvas, player_ui_slot{ZOrder := 25, InputMode := ui_input_mode.All})
+        set Canvas = option{NewCanvas}
+
+    RemoveWidget():void=
+        if(RemovedCanvas := Canvas?):
+            OurPlayerUI.RemoveWidget(RemovedCanvas)
+        set Canvas = false
+
+    OnVoteButtonClicked(_:button_loud, PlayerInstigator:?player):void=
+        if(InstigatorPlayer := PlayerInstigator?):
+            Device.HandleVoteButtonClicked(InstigatorPlayer)
+        else:
+            Device.HandleVoteButtonClicked(AssociatedPlayer)
+
+    CreateVoteSelectionUI():canvas=
+        canvas:
+            Slots := array:
+                canvas_slot:
+                    Anchors := anchors{Minimum := vector2{X := 0.5, Y := 0.85}, Maximum := vector2{X := 0.5, Y := 0.85}}
+                    Alignment := vector2{X := 0.5, Y := 0.5}
+                    SizeToContent := true
+                    Widget := border:
+                        BackgroundColor := color{R := 0.08, G := 0.08, B := 0.1, A := 0.85}
+                        Padding := margin{Left := 20.0, Right := 20.0, Top := 16.0, Bottom := 16.0}
+                        Content := stack_box:
+                            Orientation := orientation.Vertical
+                            Slots := array:
+                                stack_box_slot:
+                                    HorizontalAlignment := horizontal_alignment.Center
+                                    Padding := margin{Bottom := 6.0}
+                                    Widget := VoteTitle
+                                stack_box_slot:
+                                    HorizontalAlignment := horizontal_alignment.Center
+                                    Padding := margin{Bottom := 10.0}
+                                    Widget := VoteDescription
+                                stack_box_slot:
+                                    HorizontalAlignment := horizontal_alignment.Center
+                                    Widget := VoteButton
+
+vote_selection_widget_device := class(creative_device):
+    var WidgetsPerPlayer : [player]vote_selection_widget = map{}
+    var IsActive : logic = false
+    VoteButtonClickedInternal : event(player) = event{}
+
+    OnVoteButtonClickedEvent():event(player)=
+        VoteButtonClickedInternal
+
+    OnBegin<override>()<suspends>:void=
+        Print("Vote selection widget device initialized")
+        GetPlayspace().PlayerAddedEvent().Subscribe(HandlePlayerAdded)
+
+    ShowVoteSelectionUI():void=
+        if(IsActive = true):
+            return
+        Print("Showing vote selection UI for all players")
+        set IsActive = true
+
+        AllPlayers := GetPlayspace().GetPlayers()
+        for (PlayerAgent : AllPlayers):
+            AddWidgetForAgent(PlayerAgent)
+
+    HideVoteSelectionUI():void=
+        if(IsActive = false):
+            return
+        Print("Hiding vote selection UI for all players")
+        set IsActive = false
+
+        for(Key->Value : WidgetsPerPlayer):
+            Value.RemoveWidget()
+        set WidgetsPerPlayer = map{}
+
+    HandlePlayerAdded(NewAgent:agent):void=
+        if(IsActive = false):
+            return
+        AddWidgetForAgent(NewAgent)
+
+    AddWidgetForAgent(InAgent:agent):void=
+        if(InPlayer := player[InAgent]):
+            if(PlayerUI := GetPlayerUI[InPlayer]):
+                if(WidgetsPerPlayer[InPlayer] = false):
+                    PerPlayerWidget:vote_selection_widget = vote_selection_widget{
+                        Device := Self,
+                        OurPlayerUI := PlayerUI,
+                        AssociatedPlayer := InPlayer
+                    }
+                    PerPlayerWidget.InitWidget()
+                    if(set WidgetsPerPlayer[InPlayer] = PerPlayerWidget){}
+
+    HandleVoteButtonClicked(InPlayer:player):void=
+        Print("Player {InPlayer} interacted with vote selection button")
+        VoteButtonClickedInternal.Broadcast(InPlayer)


### PR DESCRIPTION
## Summary
- add a reusable vote selection widget device that presents an always-available voting button during mode selection
- update the main game rule device to trigger the vote widget visibility via vote group start/end events, subscribe to its interaction event, and guard teleport timing
- expose a player-specific interaction event from the vote widget device so other systems can react to button presses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df9c8fbaa4832eb464c2af2994b319